### PR TITLE
Update RF12_Demo_atmega328.ino

### DIFF
--- a/firmware/RF12_Demo_atmega328/RF12_Demo_atmega328.ino
+++ b/firmware/RF12_Demo_atmega328/RF12_Demo_atmega328.ino
@@ -39,8 +39,8 @@ typedef struct {
 static RF12Config config;
 
 static char cmd;
-static byte value, stack[20], top, sendLen, dest, quiet;
-static byte testbuf[20], testCounter;
+static byte value, stack[66], top, sendLen, dest, quiet;
+static byte testbuf[66], testCounter;
 
 
 static void saveConfig () {


### PR DESCRIPTION
Increase transmit buffer sizes from 20 to 66 bytes for use by Emoncms PacketGen Modules
